### PR TITLE
Remove expensive HSB calls

### DIFF
--- a/sketch/colors.cpp
+++ b/sketch/colors.cpp
@@ -164,10 +164,10 @@ void pulseColorOnFace(Color color, byte face, byte pulseDimness) {
 
 void sparkle() {
   FOREACH_FACE(f) {
-    byte randomH = random(360);
-    byte randomS = random(100);
-    byte randomB = random(40);  // 40% max brightness
-    Color randomColor = makeColorHSBMapped(randomH, randomS, randomB);
+    byte randomR = random(32);
+    byte randomG = random(32);
+    byte randomB = random(32);
+    Color randomColor = MAKECOLOR_5BIT_RGB(randomR, randomG, randomB);
     setColorOnFace(randomColor, f);
   }
 }
@@ -181,11 +181,4 @@ void spinColor(Color color, long revolutionMs) {
   setColorOnFace(dim(color, 120), CCW_FROM_FACE(spinMapped, 3));
   setColorOnFace(dim(color, 80), CCW_FROM_FACE(spinMapped, 4));
   setColorOnFace(dim(color, 40), CCW_FROM_FACE(spinMapped, 5));
-}
-
-Color makeColorHSBMapped(word h, word s, word b) {
-  byte mappedH = map(h, 0, 360, 0, 255);
-  byte mappedS = map(s, 0, 100, 0, 255);
-  byte mappedB = map(b, 0, 100, 0, 255);
-  return makeColorHSB(mappedH, mappedS, mappedB);
 }

--- a/sketch/colors.h
+++ b/sketch/colors.h
@@ -8,18 +8,18 @@
 #include "states.h"
 #include "util.h"
 
-#define COLOR_NONE MAKECOLOR_5BIT_RGB(1, 1, 1)             // almost off
-#define COLOR_SOIL makeColorRGB(170, 145, 134)             // i know there is no brown, but...
-#define COLOR_SPROUT makeColorRGB(191, 255, 0)             // lime greenish
-#define COLOR_GROWTH makeColorRGB(84, 164, 222)            // water vibes
-#define COLOR_TRUNK makeColorRGB(255, 192, 0)              // basically orange
-#define COLOR_BUD COLOR_SPROUT                             // lime greenish
-#define COLOR_BRANCH COLOR_TRUNK                           // basically orange
-#define COLOR_NEW_LEAF makeColorHSBMapped(100, 50, 70)     // another light green
-#define COLOR_YOUNG_LEAF makeColorHSBMapped(121, 60, 70)   // light green
-#define COLOR_MATURE_LEAF makeColorHSBMapped(121, 70, 50)  // deep green
-#define COLOR_DYING_LEAF makeColorHSBMapped(60, 60, 90)    // pale yellow
-#define COLOR_DEAD_LEAF makeColorHSBMapped(30, 60, 60)     // "brown"
+#define COLOR_NONE MAKECOLOR_5BIT_RGB(1, 1, 1)       // almost off
+#define COLOR_SOIL makeColorRGB(170, 145, 134)       // i know there is no brown, but...
+#define COLOR_SPROUT makeColorRGB(191, 255, 0)       // lime greenish
+#define COLOR_GROWTH makeColorRGB(84, 164, 222)      // water vibes
+#define COLOR_TRUNK makeColorRGB(255, 192, 0)        // basically orange
+#define COLOR_BUD COLOR_SPROUT                       // lime greenish
+#define COLOR_BRANCH COLOR_TRUNK                     // basically orange
+#define COLOR_NEW_LEAF makeColorRGB(119, 179, 89)    // another light green
+#define COLOR_YOUNG_LEAF makeColorRGB(71, 179, 73)   // light green
+#define COLOR_MATURE_LEAF makeColorRGB(51, 128, 52)  // deep green
+#define COLOR_DYING_LEAF makeColorRGB(230, 230, 92)  // pale yellow
+#define COLOR_DEAD_LEAF makeColorRGB(153, 107, 61)   // "brown"
 
 void updateColors();
 
@@ -27,6 +27,5 @@ void pulseColor(Color color, byte pulseDimness);
 void pulseColorOnFace(Color color, byte face, byte pulseDimness);
 void sparkle();
 void spinColor(Color color, long revolutionMs);
-Color makeColorHSBMapped(word h, word s, word b);
 
 #endif


### PR DESCRIPTION
Based on the Blinks dev community, HSB colors are expensive. This change saved 4% storage.